### PR TITLE
feature: cached queries on redis

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,4 +2,3 @@
 --tty
 --format progress
 --order random
---backtrace

--- a/apress-utils.gemspec
+++ b/apress-utils.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'authlogic', '~> 3'
   spec.add_runtime_dependency 'pg'
   spec.add_runtime_dependency 'string_tools', '>= 0.2.0'
+  spec.add_runtime_dependency "redis"
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
@@ -29,4 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'combustion', '>= 0.5.2'
   spec.add_development_dependency 'appraisal'
+  spec.add_development_dependency "mock_redis", ">= 0.14"
+  spec.add_development_dependency "test_after_commit"
+  spec.add_development_dependency "pry-debugger"
 end

--- a/lib/apress/utils/extensions/active_record/cached_queries.rb
+++ b/lib/apress/utils/extensions/active_record/cached_queries.rb
@@ -1,27 +1,40 @@
 # coding: utf-8
+require "digest/sha1"
+
 module Apress::Utils::Extensions::ActiveRecord::CachedQueries
   extend ActiveSupport::Concern
 
   c = Rails.application.config
   if c.respond_to?(:perform_caching_queries) && c.perform_caching_queries
     included do
-      after_save { |m| m.class.reset_cached_queries! }
+      after_save { |record| record.class.reset_cached_queries! }
+      after_destroy { |record| record.class.reset_cached_queries! }
+      after_rollback { |record| record.class.reset_cached_queries! }
     end
 
     module ClassMethods
       def find_by_sql(sql, binds = [])
         binds_key = binds.map { |x| "#{x[0].name}:#{x[1].to_s}" } * ','
-        cache_key = Digest::MD5.hexdigest("#{query_key(sql, binds.dup)}#{binds_key}")
+        cache_key = Digest::SHA1.hexdigest("#{query_key(sql, binds.dup)}#{binds_key}")
 
-        records = Rails.cache.fetch(cache_key, tags: [cache_tag]) do
-          connection.select_all(sanitize_sql(sql), "#{name} Load", binds)
+        if records = query_cache.hget(group_query_key, cache_key)
+          records = Marshal.load(records)
+        else
+          records = connection.select_all(sanitize_sql(sql), "#{name} Load", binds)
+          query_cache.hset(group_query_key, cache_key, Marshal.dump(records))
         end
 
-        records.map { |r| instantiate(r) }
+        records.map { |record| instantiate(record) }
       end
 
       def reset_cached_queries!
-        Rails.cache.delete_by_tags([cache_tag])
+        query_cache.del(group_query_key)
+      end
+
+      private
+
+      def group_query_key
+        @query_key ||= "#{table_name}-query-cache"
       end
 
       def query_key(sql, binds)
@@ -29,8 +42,8 @@ module Apress::Utils::Extensions::ActiveRecord::CachedQueries
         query_string = query.respond_to?(:ast) ? connection.to_sql(query, binds) : query.to_s
       end
 
-      def cache_tag
-        "#{table_name}-queries"
+      def query_cache
+        @query_cache ||= Rails.application.config.query_cache_store.call
       end
     end
   end

--- a/spec/internal/app/models/cached_query.rb
+++ b/spec/internal/app/models/cached_query.rb
@@ -1,0 +1,3 @@
+class CachedQuery < ActiveRecord::Base
+  include Apress::Utils::Extensions::ActiveRecord::CachedQueries
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -1,3 +1,5 @@
 ActiveRecord::Schema.define do
-  #
+  create_table :cached_queries do |t|
+    t.string :name
+  end
 end

--- a/spec/lib/apress/utils/extensions/active_record/cached_queries_spec.rb
+++ b/spec/lib/apress/utils/extensions/active_record/cached_queries_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe Apress::Utils::Extensions::ActiveRecord::CachedQueries do
+  let(:model) { CachedQuery }
+
+  it "cache records" do
+    model.create name: "test"
+    expect(model.first).to be_present
+    model.delete_all
+    expect(model.first).to be_present
+    Redis.current.flushdb
+    expect(model.first).to be_nil
+  end
+
+  it "clear cache after destroy" do
+    record = model.create name: "test"
+    expect(model.first).to be_present
+    record.destroy
+    expect(model.first).to be_nil
+  end
+
+  it "clear cache after save" do
+    record = model.create name: "test"
+    expect(model.first).to be_present
+    record.update_attributes(name: "test2")
+    expect(model.first.name).to eq "test2"
+  end
+
+  it "clear all caches" do
+    model.create name: "test"
+    expect(model.first).to be_present
+    model.delete_all
+    Rails.cache.clear
+    expect(model.first).to be_nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,21 @@ require 'combustion'
 
 require 'apress/utils'
 
-Combustion.initialize! :active_record
+Combustion.initialize! :all do
+  config.perform_caching_queries = true
+  config.cache_store = :memory_store
+end
 
 require 'rspec/rails'
+require "pry-debugger"
+require "test_after_commit"
+require "redis"
+require "mock_redis"
+redis = MockRedis.new
+Redis.current = redis
 
 RSpec.configure do |config|
-  config.backtrace_exclusion_patterns = [/lib\/rspec\/(core|expectations|matchers|mocks)/]
+  config.before do
+    Redis.current.flushdb
+  end
 end


### PR DESCRIPTION
Цель: уменьшение чтений из мемкеша.
Т.к. использовалось тегирование, то мы имели как минимум два запроса в мемкеш.
Также из мемкеша быстро вымываются данные.

@abak-press/pullviewers 
