### PR TITLE
fix: allow to include standalone module

### DIFF
--- a/lib/apress/utils/email_validation.rb
+++ b/lib/apress/utils/email_validation.rb
@@ -1,10 +1,15 @@
 # coding: utf-8
 
 # Public: Содержит регулярное выражение необходимое для валидации email.
-module Apress::Utils::EmailValidation
-  EMAIL_REGEXP = /\A[a-z0-9\-_]+(?:\.[a-z0-9\-\._]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}\Z/i
+module Apress
+  module Utils
+    module EmailValidation
+      EMAIL_REGEXP = /\A[a-z0-9\-_]+(?:\.[a-z0-9\-\._]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}\Z/i
 
-  def self.regexp
-    EMAIL_REGEXP
+      def regexp
+        EMAIL_REGEXP
+      end
+      module_function :regexp
+    end
   end
 end


### PR DESCRIPTION
if require apress/utils/email_validation it raised error
NameError: uninitialized constant Apress::Utils
