### PR TITLE
fix: allow encode cache to ascii for ruby 2 also

### DIFF
--- a/lib/apress/utils/engine.rb
+++ b/lib/apress/utils/engine.rb
@@ -45,11 +45,9 @@ module Apress
           ActionDispatch::Routing::Mapper.send(:include, ::Apress::Utils::Extensions::ActionDispatch::RoutesLoader)
         end
 
-        if RUBY_VERSION < '2'
-          require cd + '/extensions/readthis/cache'
+        require cd + '/extensions/readthis/cache'
 
-          Readthis::Cache.send(:include, ::Apress::Utils::Extensions::Readthis::Cache)
-        end
+        Readthis::Cache.send(:include, ::Apress::Utils::Extensions::Readthis::Cache)
       end
     end
   end


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-18574

Беда таже самая

Сейчас покапал поглубже
Воспроизводится только на проде, только на опрделенных строках
Проблема в преобразованиях в readthis при дампе значений тут -
https://github.com/abak-press/readthis/blob/master/lib/readthis/entity.rb#L91-L94
тк сам Marchal дампит значение совместимое с utf-8