### PR TITLE
fix: avoid double call of html_safe during read fragment

### DIFF
--- a/lib/apress/utils/extensions/content_for_cache.rb
+++ b/lib/apress/utils/extensions/content_for_cache.rb
@@ -32,14 +32,13 @@ module ActionController
 
       def read_fragment_with_content_to_cache(key, options = nil)
         result = read_fragment_without_content_to_cache(key, options)
-        if result.is_a?(Hash) && result.key?(:layout)
-          result = result.dup if result.frozen?
-          fragment = result.delete(:layout)
-          self.cached_content_for = {}.merge(result)
-          result = fragment
-        end
+        # actionpack-3.2.22.5/lib/action_controller/caching/fragments.rb:76
+        return result unless result.is_a?(Hash) && result.key?(:layout)
 
-        result.respond_to?(:html_safe) ? result.html_safe : result
+        result = result.dup if result.frozen?
+        fragment = result.delete(:layout)
+        self.cached_content_for = {}.merge(result)
+        fragment.respond_to?(:html_safe) ? fragment.html_safe : fragment
       end
 
       alias_method_chain :write_fragment, :content_to_cache

--- a/lib/apress/utils/extensions/content_for_cache.rb
+++ b/lib/apress/utils/extensions/content_for_cache.rb
@@ -32,12 +32,13 @@ module ActionController
 
       def read_fragment_with_content_to_cache(key, options = nil)
         result = read_fragment_without_content_to_cache(key, options)
-        # actionpack-3.2.22.5/lib/action_controller/caching/fragments.rb:76
-        return result unless result.is_a?(Hash) && result.key?(:layout)
+
+        return result if !result.is_a?(Hash) || !result.key?(:layout)
 
         result = result.dup if result.frozen?
         fragment = result.delete(:layout)
         self.cached_content_for = {}.merge(result)
+
         fragment.respond_to?(:html_safe) ? fragment.html_safe : fragment
       end
 

--- a/spec/lib/apress/utils/extensions/content_for_cache_spec.rb
+++ b/spec/lib/apress/utils/extensions/content_for_cache_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+class SomeController < ActionController::Base
+  abstract!
+end
+
+RSpec.describe ActionController::Caching::Fragments do
+  let(:controller) { SomeController.new }
+
+  describe '#read_fragment' do
+    context 'when string' do
+      let(:string_content) { 'foo bar' }
+
+      before { controller.write_fragment('some_key', string_content) }
+
+      it { expect(controller.read_fragment('some_key')).to eq string_content }
+
+      it do
+        expect_any_instance_of(String).to receive(:html_safe).once
+
+        controller.read_fragment('some_key')
+      end
+    end
+
+    if Rails::VERSION::MAJOR < 4
+      context 'when hash' do
+        context 'when has no layout' do
+          let(:hash_content) { {:foo => :bar} }
+
+          before { controller.write_fragment('some_key', hash_content) }
+
+          it { expect(controller.read_fragment('some_key')).to eq hash_content }
+        end
+
+        context 'when has layout key' do
+          let(:hash_content) { {:layout => 'some_value', :foo => :bar} }
+
+          before { controller.write_fragment('some_key', hash_content) }
+
+          it { expect(controller.read_fragment('some_key')).to eq 'some_value' }
+
+          it do
+            expect_any_instance_of(String).to receive(:html_safe).once
+
+            controller.read_fragment('some_key')
+
+            expect(controller.cached_content_for).to eq({:foo => :bar})
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,14 @@
-# coding: utf-8
 require 'bundler/setup'
 
+require 'pry-byebug'
 require 'combustion'
 
 require 'apress/utils'
 
 Combustion.initialize! :all do
+  config.action_controller.perform_caching = true
   config.perform_caching_queries = true
-  config.cache_store = :memory_store
+  config.cache_store = :memory_store, {size: 1.megabyte}
 end
 
 require 'rspec/rails'
@@ -17,4 +18,7 @@ RSpec.configure do |config|
   config.before do
     Rails.cache.clear
   end
+
+  config.filter_run_including focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
Вот здесь https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_controller/caching/fragments.rb#L76 уже вызывается html_safe, зачем повторно вызывать в конце, если результат тот же? )

тест подгоню попозже