### PR TITLE
fix: remove enum types momoization

### DIFF
--- a/lib/apress/utils/engine.rb
+++ b/lib/apress/utils/engine.rb
@@ -70,10 +70,6 @@ module Apress
 
         Readthis::Cache.send(:include, ::Apress::Utils::Extensions::Readthis::Cache)
       end
-
-      config.after_initialize do
-        ActiveRecord::Base.connection.send(:reload_type_map) if Utils.rails40?
-      end
     end
   end
 end

--- a/lib/apress/utils/extensions/active_record/connection_adapters/rails40/postgre_sql_adapter.rb
+++ b/lib/apress/utils/extensions/active_record/connection_adapters/rails40/postgre_sql_adapter.rb
@@ -18,15 +18,8 @@ module Apress
               end
 
               def enum_types
-                @enum_types ||= begin
-                                  result = execute "SELECT DISTINCT oid, typname FROM pg_type where typcategory = 'E'", 'SCHEMA'
-                                  result.to_a.each_with_object({}) { |row, h| h[row['oid'].to_i] = row['typname'] }
-                                end
-              end
-
-              def reload_type_map
-                super
-                remove_instance_variable(:@enum_types)
+                result = execute "SELECT DISTINCT oid, typname FROM pg_type where typcategory = 'E'", 'SCHEMA'
+                result.to_a.each_with_object({}) { |row, h| h[row['oid'].to_i] = row['typname'] }
               end
 
               def initialize_type_map

--- a/lib/apress/utils/extensions/active_record/connection_adapters/rails40/postgre_sql_column.rb
+++ b/lib/apress/utils/extensions/active_record/connection_adapters/rails40/postgre_sql_column.rb
@@ -10,11 +10,12 @@ module Apress
               end
 
               def simplified_type(field_type)
-                case field_type
-                when *::ActiveRecord::Base.connection.enum_types.values
+                type = super(field_type)
+
+                return type if type
+
+                if ::ActiveRecord::Base.connection.enum_types.values.include?(field_type)
                   field_type.to_sym
-                else
-                  super(field_type)
                 end
               end
 
@@ -25,7 +26,7 @@ module Apress
 
                   if match = /\A'(.*)'::(.*)\z/.match(default)
                     if ::ActiveRecord::Base.connection.enum_types.values.include?(match[2])
-                      return match[1]
+                      match[1]
                     end
                   end
                 end


### PR DESCRIPTION
Проблема в тестах если стоит `config.eager_load = true`
енумы кешируются в пустой хеш. Как победить пока не знаю, предлагаю отключить пока кеширование чтобы тесты пошли и уже смотреть на реальном проекте как много этих запросов будет при старте приложения.
