### PR TITLE
Fix error_message_on helper on Rails 4

### DIFF
--- a/lib/apress/utils/engine.rb
+++ b/lib/apress/utils/engine.rb
@@ -40,7 +40,6 @@ module Apress
             Extensions::ActiveRecord::ConnectionAdapters::Rails40::PostgreSQLColumn
           )
 
-          ActionView::Helpers::ActiveModelInstanceTag.include(::Apress::Utils::Extensions::ActionView::Helpers::InstanceTag)
         end
 
         if Utils.rails32?

--- a/lib/apress/utils/extensions/action_view/helpers/form_builder.rb
+++ b/lib/apress/utils/extensions/action_view/helpers/form_builder.rb
@@ -16,6 +16,23 @@ module Apress::Utils::Extensions::ActionView::Helpers::FormBuilder
 
   def error_message_on(method, options = {})
     options = objectify_options(options)
-    ::ActionView::Helpers::InstanceTag.new(@object_name, method, self, options.delete(:object)).to_error_message_tag(options)
+
+    if Rails::VERSION::MAJOR <= 3
+      instance_tag = ::ActionView::Helpers::InstanceTag.new(@object_name, method, self, options.delete(:object))
+      instance_tag.to_error_message_tag(options)
+    else
+      object = options[:object]
+      return unless object
+
+      instance_tag = ActionView::Helpers::Tags::Base.new(@object_name, method, self, options)
+
+      errors = []
+      object.errors.each { |attr, err| errors.push(err) if attr.to_s == method.to_s }
+      return if errors.empty?
+
+      options[:class] ||= 'form-error'
+      # пока показываем тольк первую ошибку, возможно нужно показывать все?
+      instance_tag.content_tag(:span, "#{errors.first}".html_safe, options)
+    end
   end
 end


### PR DESCRIPTION
немного поправлен [старый](https://github.com/Napolskih/apress-utils/blob/581515f1f1e7a8de2df736feb95fe7d006544006/lib/apress/utils/extensions/action_view/helpers/instance_tag.rb#L4) код под 4 рельсы.